### PR TITLE
[rpm] Make evcap a noarch package

### DIFF
--- a/rpm/evcap.spec
+++ b/rpm/evcap.spec
@@ -5,6 +5,7 @@ Release:    1
 Group:      System/Boot
 License:    MIT
 Source0:    %{name}-%{version}.tar.gz
+BuildArch:  noarch
 
 %description
 %{summary}.


### PR DESCRIPTION
Since evcap is just a shell script, it can be noarch package.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
